### PR TITLE
REOPEN: add "Quick Start Option" for experienced developer to get start quickly

### DIFF
--- a/pages/your_first_nft_set/foundry/setting_up_environment.mdx
+++ b/pages/your_first_nft_set/foundry/setting_up_environment.mdx
@@ -4,6 +4,15 @@ In order to write smart contracts on Frame, you'll need to set up [Foundry](http
 
 Foundry is a suite of tools that makes it easy to write, test, and deploy smart contracts. With Foundry, we can locally develop and test our smart contracts before launching them on testnet or mainnet.
 
+## 🚀 Quick Start Option
+If you're already experienced with Foundry and want to speed things up, here's a repo that has everything ready for you:
+
+[Get set up quickly with this repo](https://github.com/myro0x/frame-nft-example)
+
+Check the README for details, and you'll be all set in no time.
+
+For anyone new to the process, the next sections will walk you through the setup step by step.
+
 ## 🛠 Install Foundry
 
 _Note: We recommend downloading the Solidity extension for VSCode which gives nice syntax highlighting._


### PR DESCRIPTION
## Summary
Add Quick Setup Option section in Setting Up Environment page, intended for experienced developers who want to quickly try out Frame. This pull request introduces a new repository link to Frame NFT Example Repository. The linked repository simplifies the process of setting up RPC and EVM version, and also the deployment and interactions of the NFT contract.

## Changes
Inserted a concise paragraph in the "Setting up your development environment" section.
